### PR TITLE
styled page for the list of artifacts

### DIFF
--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -19,16 +19,16 @@ export const Header = ({
   <header className="" aria-labelledby="header-heading">
     <h2 id="header-heading" className="sr-only">Header</h2>
 
-    <div className="grid grid-cols-9 grid-rows-1">
+    <div className="mt-4 ml-4 mr-4 grid grid-cols-2 grid-rows-1">
       <div><a href={url} title={`Visit the ${name} website`}>
         <Logo theme="light" />
       </a> </div>
       
 
-      <div className="mt-12 -mb-6 flex justify-right space-x-4 sm:space-x-12">
+      <div className="flex justify-end mt-12 mb-6 space-x-4 sm:space-x-12">
         {headerMenuLinks.map(({ name, url }) => (
             <div className="pb-6" key={`${name}.${url}`}>
-              <a className="text-sm leading-6 text-black hover:text-grey-300"
+              <a className="text-lg leading-6 text-black hover:text-red-700"
                  data-testid="Header.HeaderMenuLink"
                  href={url}
               >

--- a/app/components/ImageOverlay/ImageOverlay.tsx
+++ b/app/components/ImageOverlay/ImageOverlay.tsx
@@ -31,8 +31,8 @@ export const ImageOverlay = ({
 
   const overlaytext = classNames(
     "relative",
-    "w-40",
-    "top-32",
+    "w-52",
+    "bottom-14",
     "flex",
     "justify-center",
     "place-content-center",
@@ -45,9 +45,10 @@ export const ImageOverlay = ({
   );
 
   const image = classNames(
-    "absolute",
-    "w-40",
-    "h-40"
+    "relative",
+    "w-52",
+    "h-52",
+    "rounded-md"
   );
   
   return (

--- a/app/routes/__public.tsx
+++ b/app/routes/__public.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "@remix-run/react";
 
+import { Header } from "../components/Header"
 import { Footer } from "../components/Footer";
 import { MuseumSiteInfo } from "../models";
 
@@ -9,6 +10,7 @@ const year = today.getFullYear().toString();
 export default function Layout() {
   return (
     <>
+      <Header currentYear={year} siteInfo={MuseumSiteInfo}/>
       <main className="grow w-full mx-auto max-w-7xl sm:px-6 lg:px-8 py-6 lg:py-8">
         <Outlet />
       </main>

--- a/app/routes/__public/index.tsx
+++ b/app/routes/__public/index.tsx
@@ -1,6 +1,7 @@
 import type { LoaderArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
+import { ImageOverlay } from "~/components/ImageOverlay";
 
 import { ArtifactService } from "../../services.server";
 
@@ -14,12 +15,11 @@ export default function Index() {
   const artifacts = useLoaderData<typeof loader>();
 
   return (
-    <ul className="space-y-6">
+    <ul className="grid grid-cols-4 justify-center place-items-center">
       {artifacts.map(({ id, image, name }) => (
         <li key={id}>
-          <a className="text-blue-500 hover:underline" href={`/artifacts/${id}`}>
-            {image && <img src={image.url} alt={image.caption} />}
-            {name}
+          <a className="text-blue-500" href={`/artifacts/${id}`}>
+            <ImageOverlay url={image.url} text={name} alt={image.caption}/>
           </a>
         </li>
       ))}


### PR DESCRIPTION
- Built out the artifacts page by accessing data in SupaBase and utilizing the ImageOverlay component. Artifacts added to the database will be reflective here with four artifacts per row with overflow resulting in a new row.
- Added the header with minor styling changes


![artifacts](https://user-images.githubusercontent.com/122938256/233910248-072ff882-9f2d-4fdf-b4f0-1c10afc89a74.png)
