### PR TITLE
Implement responsive admin panel

### DIFF
--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { NavLink } from "@remix-run/react";
 
+import { ArrowLeftOnRectangleIcon } from "@heroicons/react/20/solid";
+
 import { Button } from "../Button";
 
 type SidebarProps = {
@@ -22,26 +24,26 @@ type SidebarProps = {
 };
 
 export const Sidebar = ({ links, user }: SidebarProps) => (
-  <aside className="bg-slate-100 border-r border-slate-200 h-screen flex flex-col justify-between inset-0 px-2 py-4 w-64 sticky">
+  <aside className="bg-slate-100 border-r border-slate-200 h-screen flex flex-col justify-between inset-0 px-2 py-4 w-16 sm:w-36 md:w-64 sticky">
     <div>
       <div className="flex flex-col items-center pb-4 mb-4 border-b border-slate-200">
         <img src="/img/logo-transparent.png" width="50%" height="auto" alt="" />
-        <h1 className="text-brown-800 uppercase font-bold m-0 leading-1 text-md"><span className="text-blue-500">AR</span>chaeology</h1>
-        <h2 className="text-slate-500 -mt-1 text-sm font-light">Admin Panel</h2>
+        <h1 className="hidden sm:block text-brown-800 uppercase font-bold m-0 leading-1 text-md"><span className="text-blue-500">AR</span>chaeology</h1>
+        <h2 className="hidden sm:block text-slate-500 -mt-1 text-sm font-light">Admin Panel</h2>
       </div>
       <nav>
         <ul className="space-y-1">
           {links.map(({ Icon, title, url }) => (
             <li key={url}>
               <NavLink end to={url} className={({ isActive, isPending }) =>
-                `${isActive ? 'bg-slate-200 text-slate-800' : 'bg-slate-100 text-slate-600 hover:text-slate-800'} text-sm flex group items-center p-2 rounded-md duration-300 ease-out hover:ease-in transition-all`
+                `${isActive ? 'bg-slate-200 text-slate-800' : 'bg-slate-100 text-slate-600 hover:text-slate-800'} text-sm flex group items-center justify-center sm:justify-start p-2 rounded-md duration-300 ease-out hover:ease-in transition-all`
               }>
                 {({ isActive, isPending }) => (
                   <>
                     <Icon aria-hidden={true} className={
-                      `${isActive ? 'text-slate-500' : 'text-slate-400 group-hover:text-slate-500 group-hover:ease-in transition duration-300'} mr-3 h-6 w-6 flex-shrink-0`
+                      `${isActive ? 'text-slate-500' : 'text-slate-400 group-hover:text-slate-500 group-hover:ease-in transition duration-300'} sm:mr-3 h-6 w-6 flex-shrink-0`
                     } />
-                    {title}
+                    <span className="hidden sm:inline">{title}</span>
                   </>
                 )}
               </NavLink>
@@ -50,7 +52,7 @@ export const Sidebar = ({ links, user }: SidebarProps) => (
         </ul>
       </nav>
     </div>
-    <div className="group flex items-center justify-between border-t border-slate-200 pt-4 mt-4">
+    <div className="hidden sm:flex group items-center justify-between border-t border-slate-200 pt-4 mt-4">
       <img className="h-10 w-10 flex-shrink-0 rounded-full bg-slate-300 mr-1" alt={user.role} src={user.image} />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-slate-900">
@@ -62,6 +64,12 @@ export const Sidebar = ({ links, user }: SidebarProps) => (
           </Button>
         </span>
       </span>
+    </div>
+    <div className="sm:hidden group">
+      <Button inverse size="small" href="/sign-out">
+        <ArrowLeftOnRectangleIcon className="h-6 w-6 text-slate-400 group-hover:text-slate-500" />
+        <span className="sr-only">Sign Out</span>
+      </Button>
     </div>
   </aside>
 )

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -51,7 +51,7 @@ export default function Admin() {
           email,
         }}
       />
-      <main className="p-4 grow">
+      <main className="p-4 flex-1 overflow-hidden">
         <Outlet context={{ token }} />
       </main>
     </div>

--- a/app/routes/admin/artifacts/index.tsx
+++ b/app/routes/admin/artifacts/index.tsx
@@ -51,7 +51,7 @@ export default function Artifacts() {
         </div>
       </div>
       <div className="mt-8 flow-root">
-        <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+        <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
           <table className="min-w-full divide-y divide-slate-300">
             <thead className="bg-slate-50">
               <tr>

--- a/app/routes/admin/index.tsx
+++ b/app/routes/admin/index.tsx
@@ -5,7 +5,7 @@ import { Button, Warning } from "../../components";
 export default function Admin() {
   return (
     <>
-      <div className="text-center pt-12 w-8/12 mx-auto">
+      <div className="text-center pt-12 md:w-8/12 mx-auto">
         <h2 className="text-3xl font-bold tracking-tight text-slate-900">
           Welcome to ARchaeology
         </h2>
@@ -14,7 +14,7 @@ export default function Admin() {
           3D images for augmented reality exhibits.
         </p>
       </div>
-      <ul className="mx-auto mt-20 grid max-w-2xl grid-cols-2">
+      <ul className="mx-auto mt-20 grid max-w-2xl grid-cols-1 gap-6 md:grid-cols-2">
         <li className="block group text-slate-400 text-center px-6">
           <div className="w-40 h-40 mx-auto inline-flex items-center justify-center p-8 bg-slate-100 rounded-full">
             <BuildingLibraryIcon className="h-full w-full" />

--- a/app/routes/admin/users.tsx
+++ b/app/routes/admin/users.tsx
@@ -32,7 +32,7 @@ export default function Users() {
         users.
       </Warning>
       <div className="mt-8 flow-root">
-        <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+        <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
           <table className="min-w-full divide-y divide-slate-300">
             <thead className="bg-slate-50">
               <tr>


### PR DESCRIPTION
This update gives the admin panel a responsive layout.

Examples:

![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-25 at 01 02 27](https://user-images.githubusercontent.com/431654/234179082-9849008c-dd0a-4c25-a9f7-e38de7b7e555.png)

![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-25 at 01 03 15](https://user-images.githubusercontent.com/431654/234179096-09899029-ec52-4edd-9cbd-f7a6e78af30b.png)
